### PR TITLE
Implementation of a discard-token button

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -12,12 +12,14 @@ import {
   ONION_DOMAIN_PORT,
   VERBOSE,
   SCHEME,
-  ONION_SCHEME
+  ONION_SCHEME,
+  REDEMPTION_ENDPOINTS
 } from './scripts/config.js'
 
 import {
   genTokens,
   setPPHeaders,
+  forceLoadNextToken,
 } from './scripts/generation_and_redemption.js';
 
 import {
@@ -62,6 +64,11 @@ chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
   } else if (message == "onion_set_new_search_token") {
     // the redirector was invoked, to be sure load a new token
     await setPPHeaders(`${ONION_SCHEME}://${ONION_DOMAIN_PORT}/search`)
+  } else if (message == "force_load_next_token") {
+    for (let i = 0; i < REDEMPTION_ENDPOINTS.length; i++) {
+      let endpoint = REDEMPTION_ENDPOINTS[i];
+      await forceLoadNextToken(endpoint);
+    }
   } else {
     await logError(UI_COMMAND_NOT_RECOGNIZED_ERROR);
   }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -153,7 +153,7 @@ function open_settings() {
   if (!browser.windows) {
     return;
   }
-  const height = 220;
+  const height = 260;
   const width = 240;
   const top = screen.height / 2 - height / 2;
   const left = screen.width / 2 - width / 2;

--- a/src/popup/settings.html
+++ b/src/popup/settings.html
@@ -15,11 +15,16 @@
         <div class="tokens">Extension</div>
       </div>
       <div class="frame-1808">
+        <div id="kagipp-discard-current-token" class="button">
+          <div class="tertiary-button">
+            <div class="tertiary">Discard current token</div>
+            <img id="kagipp-discard-current-token-check" class="checkmark" src="../images/check.svg" />
+          </div>
+        </div>
         <div id="kagipp-clear-state" class="button">
           <div class="tertiary-button">
             <div class="tertiary">Clear state (erases tokens!)</div>
           </div>
-          <!-- <img src="../images/generate-tokens.svg"/> -->
         </div>
       </div>
     </div>

--- a/src/popup/settings.js
+++ b/src/popup/settings.js
@@ -10,6 +10,8 @@ const clearstatebtn = document.querySelector("#kagipp-clear-state")
 const sessioncookieinp = document.querySelector("#kagipp-session-cookie")
 const savesessioncookiebtn = document.querySelector("#kagipp-save-session-cookie")
 const savesessioncookiecheck = document.querySelector("#kagipp-save-session-cookie-check")
+const discardtokenbtn = document.querySelector("#kagipp-discard-current-token")
+const discardtokencheck = document.querySelector("#kagipp-discard-current-token-check")
 
 async function generate_tokens() {
   // attempt to generate tokens
@@ -22,6 +24,19 @@ async function generate_tokens() {
 
 if (generatebtn) {
   generatebtn.addEventListener("click", generate_tokens)
+}
+
+async function discard_current_token() {
+  browser.runtime.sendMessage('force_load_next_token');
+
+  discardtokencheck.style.display = "inline";
+  setTimeout(() => {
+    discardtokencheck.style.display = "none";
+  }, 1000)
+}
+
+if (discardtokenbtn) {
+  discardtokenbtn.addEventListener("click", discard_current_token)
 }
 
 async function clear_state() {


### PR DESCRIPTION
Unstable internet connections may trigger a double-spend token state that is hard to recover from.
Adding a "discard current token" button that will remove the currently held-but-already-spent token from the system.