### PR TITLE
Reducing the number of tokens generated to 300 per round.

### DIFF
--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -118,7 +118,7 @@ export {
 }
 
 // token generation settings
-export const TOKENS_TO_STASH = 500;
+export const TOKENS_TO_STASH = 300;
 export const MAX_TOKENS = 2000;
 export const LOW_TOKEN_COUNT = 50; // if available tokens below this threshold, show counts
 


### PR DESCRIPTION
This allows to keep a 2100 monthly limit while increasing the number of devices PP can be set up to 7 per month.